### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Execute Gradle commands in Github Actions workflows
+# Execute Gradle commands in GitHub Actions workflows
 
-This Github Action can be used to run arbitrary Gradle commands on any platform supported by Github Actions.
+This GitHub Action can be used to run arbitrary Gradle commands on any platform supported by GitHub Actions.
 
-You might also be interested by the related [Gradle Plugin](https://github.com/eskatos/gradle-github-actions-plugin) that allows your build to easily get Github Actions environment and tag Gradle Build Scans accordingly.
+You might also be interested by the related [Gradle Plugin](https://github.com/eskatos/gradle-github-actions-plugin) that allows your build to easily get GitHub Actions environment and tag Gradle Build Scans accordingly.
 
 ## Usage
 
@@ -46,7 +46,7 @@ arguments: build -DsystemProperty=bar
 
 See `gradle --help` for more information.
 
-If you need to pass environment variables, simply use the Github Actions workflow syntax:
+If you need to pass environment variables, simply use the GitHub Actions workflow syntax:
 
 ```yaml
 - uses: eskatos/gradle-command-action@v1

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import * as gradlew from "./gradlew";
 import * as provision from "./provision";
 
 
-// Invoked by Github Actions
+// Invoked by GitHub Actions
 export async function run() {
     try {
 


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.