### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ If the defaults don't suit your needs you can override them with the following i
 ```yaml
 dependencies-cache-key: |
   **/gradle.properties
-  gradle/dependency-locking/**
+  gradle/dependency-locks/**
 dependencies-cache-exact: true
 configuration-cache-key: |
   **/gradle.properties
-  gradle/dependency-locking/**
+  gradle/dependency-locks/**
 configuration-cache-exact: true
 ```
 
@@ -179,7 +179,7 @@ If you happen to use Gradle [dependency locking](https://docs.gradle.org/current
 
 ```yaml
 dependencies-cache-enabled: true
-dependencies-cache-key: gradle/dependency-locking/**
+dependencies-cache-key: gradle/dependency-locks/**
 dependencies-cache-exact: true
 ```
 


### PR DESCRIPTION
This pull request fixes small typo in README - the actual directory which contains dependency lock files is named ``gradle/dependency-locks/`` and not ``gradle/dependency-locking/``.

```bash
ls -la gradle/dependency-locks/
total 24
drwxrwxr-x. 2 kami kami 4096 sep 22 19:32 .
drwxrwxr-x. 4 kami kami 4096 sep 22 16:22 ..
-rw-rw-r--. 1 kami kami  644 sep 22 19:32 buildscript-classpath.lockfile
-rw-rw-r--. 1 kami kami 8685 sep 22 19:32 compileClasspath.lockfile
```

Perhaps, we could also update glob to ``gradle/dependency-locks/*.lockfile`` to be on the safe side.