### PR TITLE
Add working example for build scan comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,16 @@ jobs:
       with:
         arguments: build
       id: gradle
-    - uses: example/action-that-comments-on-the-pr@v0
-      if: failure()
+    - name: "Comment build scan url"
+      uses: actions/github-script@v3
+      if: github.event_name == 'pull_request' && failure()
       with:
-        comment: Build failed ${{ steps.gradle.outputs.build-scan-url }}
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '❌ ${{ github.workflow }} failed: ${{ steps.gradle.outputs.build-scan-url }}'
+          })
 ```


### PR DESCRIPTION
Replaces the dummy example for how to automatically add a comment containing the build scan URL
with a working example using the [GitHub Script action](https://github.com/marketplace/actions/github-script#comment-on-an-issue).

See https://github.com/britter/maven-plugin-development/pull/56#issuecomment-708406163 for how it looks in action.